### PR TITLE
Fix media query style

### DIFF
--- a/style.css
+++ b/style.css
@@ -424,12 +424,10 @@ color: var(--green);
   } */
 
 @media (max-width: 768px) {
-    body {
-        .container {
-            width: 100%;
-            max-width: 100%;
-            box-sizing: border-box;
-        }
+    .container {
+        width: 100%;
+        max-width: 100%;
+        box-sizing: border-box;
     }
 
     h1 {


### PR DESCRIPTION
## Summary
- target `.container` directly inside the media query instead of wrapping it in `body`

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6840578c4ce8832ca611cb7d1d7dc49b